### PR TITLE
Fixes for recent breaking changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,25 @@ services:
     restart: always
     depends_on:
     - webapp
-  worker:
+  checker:
     build: .
-    command: worker
+    command: checker
+    restart: always
+    volumes:
+    - "./:/opt/app/"
+    depends_on:
+    - webapp
+  svcmanager:
+    build: .
+    command: svcmanager
+    restart: always
+    volumes:
+    - "./:/opt/app/"
+    depends_on:
+    - webapp
+  flagrotator:
+    build: .
+    command: flagrotator
     restart: always
     volumes:
     - "./:/opt/app/"

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -8,4 +8,4 @@ loglevel = "info"
 accesslog = "-"
 errorlog = "-"
 capture_output = True
-preload_app = True
+preload_app = False

--- a/startup.sh
+++ b/startup.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env sh
 
-# DB migration
-cd /opt/app && python3 manage.py migrate
-
 CMD=${@:-webapp}
 echo $CMD
 cd /opt/app && python3 manage.py ${CMD}


### PR DESCRIPTION
This closes #102 

changes
1. use `Preload_app = False` for gunicorn to fix worker-to-DB connectivity issue ([reference](https://github.com/psycopg/psycopg2/issues/281#issuecomment-985387977))
2. comment out migration from entrypoint script since we do it directly as an effect on downstream components (not from user input + manage.py)
3. change command of worker instance to 'checker'